### PR TITLE
Issue #4066 - Fix default classes in header region for Flexible Layouts

### DIFF
--- a/core/modules/layout/templates/layout--flexible.tpl.php
+++ b/core/modules/layout/templates/layout--flexible.tpl.php
@@ -17,7 +17,7 @@
  *   - $row_data['region_name']: the region name.
  *   - $row_data['content_key']: The key of the $content array which contains
  *     the HTML for that region.
- * - $content: An array of content, each item in the array is nameed to one
+ * - $content: An array of content, each item in the array is named to one
  *   region of the layout.
  */
 ?>
@@ -27,7 +27,7 @@
   </div>
   <div class="layout-flexible-content <?php $region_buttons ? print 'layout-flexible-editor' : ''; ?>">
   <?php foreach ($row_data as $name => $row): ?>
-    <<?php print $row['element']; ?> data-row-id="<?php print $name; ?>" class="flexible-row <?php print 'l-' . $name; ?>" <?php print $row['row_id']; ?>>
+    <<?php print $row['element']; ?> data-row-id="<?php print $name; ?>" class="flexible-row <?php print 'l-' . $name . ' l-' . $row['element']; ?>" <?php print $row['row_id']; ?>>
       <div class="<?php print $row['row_class']; ?>">
         <?php if ($region_buttons): ?>
           <div class="layout-flexible-region-buttons clearfix">


### PR DESCRIPTION
Adds a l-[element] class to each row. In particular useful for l-header and l-footer.