### PR TITLE
Issue #4903: Adjustments to default views, layout, and CSS.

### DIFF
--- a/core/modules/node/config/views.view.promoted.json
+++ b/core/modules/node/config/views.view.promoted.json
@@ -1,7 +1,7 @@
 {
     "_config_name": "views.view.promoted",
     "name": "promoted",
-    "description": "Provides a list of promoted content, excluding Cards. Used by default on the home page.",
+    "description": "Provides a list of promoted content. Used by default on the home page.",
     "module": "node",
     "storage": 4,
     "tag": "default",
@@ -72,48 +72,6 @@
                         "expose": {
                             "operator": false
                         }
-                    },
-                    "type": {
-                        "id": "type",
-                        "table": "node",
-                        "field": "type",
-                        "relationship": "none",
-                        "group_type": "group",
-                        "ui_name": "",
-                        "operator": "not in",
-                        "value": {
-                            "card": "card"
-                        },
-                        "group": "1",
-                        "exposed": false,
-                        "expose": {
-                            "operator_id": false,
-                            "label": "",
-                            "description": "",
-                            "use_operator": false,
-                            "operator": "",
-                            "identifier": "",
-                            "required": false,
-                            "remember": false,
-                            "multiple": false,
-                            "remember_roles": {
-                                "authenticated": "authenticated"
-                            },
-                            "reduce": false
-                        },
-                        "is_grouped": false,
-                        "group_info": {
-                            "label": "",
-                            "description": "",
-                            "identifier": "",
-                            "optional": true,
-                            "widget": "select",
-                            "multiple": false,
-                            "remember": 0,
-                            "default_group": "All",
-                            "default_group_multiple": [],
-                            "group_items": []
-                        }
                     }
                 },
                 "empty": {
@@ -147,7 +105,7 @@
                     "type": "views_query",
                     "options": []
                 },
-                "block_description": "Promoted content, excluding Cards"
+                "block_description": "Promoted content"
             }
         },
         "feed": {

--- a/core/profiles/standard/config/image.style.large_cropped.json
+++ b/core/profiles/standard/config/image.style.large_cropped.json
@@ -10,7 +10,7 @@
             "data": {
                 "width": "800",
                 "height": "533",
-                "anchor": "center-center"
+                "anchor": "top-center"
             },
             "weight": 1
         }

--- a/core/profiles/standard/config/layout.layout.home.json
+++ b/core/profiles/standard/config/layout.layout.home.json
@@ -4,6 +4,7 @@
     "name": "home",
     "title": "Home page",
     "description": null,
+    "renderer_name": "standard",
     "module": "standard",
     "weight": 0,
     "storage": 4,
@@ -21,6 +22,7 @@
         ],
         "top": [
             "094cbc03-d088-4b3c-8361-977733540ae8",
+            "6a46fd7b-646b-4c91-9d03-034e630a2135",
             "fe8c7715-c7e9-46d0-8b09-09afb78b2891"
         ],
         "content": [
@@ -33,6 +35,7 @@
         "title": []
     },
     "contexts": [],
+    "relationships": [],
     "content": {
         "9bd5a524-3670-4922-8b12-18b00a2858b9": {
             "plugin": "system:header",
@@ -116,6 +119,34 @@
                 }
             }
         },
+        "6a46fd7b-646b-4c91-9d03-034e630a2135": {
+            "plugin": "system:page_components:messages",
+            "data": {
+                "module": "system",
+                "delta": "page_components",
+                "settings": {
+                    "title_display": "none",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": [],
+                    "title_tag": "h1",
+                    "title_classes": "page-title",
+                    "tab_type": "both",
+                    "admin_label": "",
+                    "admin_description": ""
+                },
+                "uuid": "6a46fd7b-646b-4c91-9d03-034e630a2135",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": "container"
+                        }
+                    }
+                }
+            }
+        },
         "fe8c7715-c7e9-46d0-8b09-09afb78b2891": {
             "plugin": "views:card_grid-block",
             "data": {
@@ -132,7 +163,7 @@
                     "fields_override": null,
                     "title_display": "none",
                     "title": "",
-                    "style": "dynamic",
+                    "style": "default",
                     "block_settings": [],
                     "contexts": [],
                     "allowed": [],
@@ -143,15 +174,10 @@
                 },
                 "uuid": "fe8c7715-c7e9-46d0-8b09-09afb78b2891",
                 "style": {
-                    "plugin": "dynamic",
+                    "plugin": "default",
                     "data": {
                         "settings": {
-                            "classes": "",
-                            "wrapper_tag": "div",
-                            "title_tag": "h2",
-                            "title_classes": "block-title",
-                            "content_tag": "div",
-                            "content_classes": "container card-design"
+                            "classes": "container"
                         }
                     }
                 }
@@ -163,11 +189,21 @@
                 "module": "views",
                 "delta": "promoted-block",
                 "settings": {
+                    "link_to_view": null,
+                    "more_link": false,
+                    "use_pager": true,
+                    "pager_id": 0,
+                    "items_per_page": 10,
+                    "offset": 0,
+                    "path": "rss.xml",
+                    "fields_override": null,
                     "title_display": "default",
                     "title": "",
                     "style": "default",
                     "block_settings": [],
-                    "contexts": []
+                    "contexts": [],
+                    "allowed": [],
+                    "path_override": false
                 },
                 "uuid": "578243cf-a4c8-46ad-9504-04aaf4ec9ccc",
                 "style": {

--- a/core/profiles/standard/standard.install
+++ b/core/profiles/standard/standard.install
@@ -63,7 +63,7 @@ function standard_install() {
   $filtered_html_format = (object) $filtered_html_format;
   filter_format_save($filtered_html_format);
 
-  // Changed display name from Full HTML to Raw HTML but keeping machine name 
+  // Changed display name from Full HTML to Raw HTML but keeping machine name
   // for backward compatibility.
   $full_html_format = array(
     'format' => 'full_html',
@@ -439,7 +439,7 @@ function standard_install() {
   );
 
   foreach ($cards as $image_filename => $info) {
-    $image_url = BACKDROP_ROOT . '/' . backdrop_get_path('profile', 'standard') . '/' . 'images/'. $image_filename; 
+    $image_url = BACKDROP_ROOT . '/' . backdrop_get_path('profile', 'standard') . '/' . 'images/'. $image_filename;
     $moved_file = file_unmanaged_copy($image_url, $field_image_dir);
 
     $file = entity_create('file', array(
@@ -480,6 +480,17 @@ function standard_install() {
 
     $card->save();
   }
+
+  // Modify the default promoted view to exclude cards.
+  $promoted_view = views_get_view('promoted');
+  $promoted_view->display['default']->display_options['filters']['type'] = array(
+    'id' => 'type',
+    'table' => 'node',
+    'field' => 'type',
+    'operator' => 'not in',
+    'value' => array('card' => 'card'),
+  );
+  $promoted_view->save();
 
   // Enable default permissions for system roles.
   $filtered_html_permission = filter_permission_name($filtered_html_format);

--- a/core/themes/basis/basis.info
+++ b/core/themes/basis/basis.info
@@ -22,6 +22,7 @@ stylesheets[all][] = css/component/admin-tabs.css
 stylesheets[all][] = css/component/breadcrumb.css
 stylesheets[all][] = css/component/pager.css
 stylesheets[all][] = css/component/hero.css
+stylesheets[all][] = css/component/cards.css
 stylesheets[all][] = css/component/teasers.css
 stylesheets[all][] = css/component/comment.css
 stylesheets[all][] = css/component/caption.css

--- a/core/themes/basis/css/component/cards.css
+++ b/core/themes/basis/css/component/cards.css
@@ -1,0 +1,50 @@
+/**
+ * @file
+ * Card listing view on the default home page.
+ */
+
+.l-top .block-views-card-grid-block {
+  margin-top: -2rem;/* Negative top margin collapses spacing under header */
+}
+.block-views-card-grid-block {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.block-views-card-grid-block .views-view-grid-cols-3 {
+  grid-template-columns: repeat(1, 1fr);
+}
+.view-card-grid .views-grid-box {
+  border: none;
+}
+
+.view-card-grid .views-grid-box {
+  border-radius: 0.25rem;
+  margin: 1rem 0;
+  padding: 0 0 1rem 0;
+  background-color: #ffffff;
+}
+.view-card-grid h2 {
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+.view-card-grid .views-field {
+  padding: 0 1rem;
+}
+.view-card-grid .views-field-field-image {
+  padding: 0;
+}
+@media (min-width: 48em) {
+  .block-views-card-grid-block .views-view-grid-cols-3 {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .view-card-grid .views-grid-box-1 {
+    margin: 1rem 1rem 1rem 0;
+  }
+  .view-card-grid .views-grid-box-2 {
+    margin: 1rem 0.5rem;
+  }
+  .view-card-grid .views-grid-box-3 {
+    margin: 1rem 0 1rem 1rem;
+  }
+}

--- a/core/themes/basis/css/skin.css
+++ b/core/themes/basis/css/skin.css
@@ -400,6 +400,9 @@ fieldset .fieldset-legend {
   }
 }
 
+.l-top {
+  background-color: #f2f2f2;
+}
 
 /**
  * Footer styles
@@ -1225,49 +1228,4 @@ div.warning:before {
 div.error:before {
   /* background-image: -webkit-linear-gradient(transparent, transparent), url(../../../misc/message-error.svg); */
   /* background-image: linear-gradient(transparent, transparent), url(../../../misc/message-error.svg); */
-}
-
-/* Card view on default home page */
-
-.block-views-card-grid-block {
-  margin-top: -2em;
-  padding-top: 2rem;
-  padding-bottom: 2rem;
-  background-color: #f2f2f2;
-}
-.block-views-card-grid-block .views-view-grid-cols-3 {
-  grid-template-columns: repeat(1, 1fr);
-}
-.view-card-grid .views-grid-box {
-  border: none;
-}
-.card-design .view-card-grid .views-grid-box {
-  border-radius: 0.25rem;
-  margin: 1rem 0;
-  padding: 0 0 1rem 0;
-  background-color: #ffffff;
-}
-.card-design .view-card-grid h2 {
-  font-size: 1.25rem;
-  font-weight: bold;
-}
-.card-design .view-card-grid .views-field {
-  padding: 0 1rem;
-}
-.card-design .view-card-grid .views-field-field-image {
-  padding: 0;
-}
-@media (min-width: 48em) {
-  .block-views-card-grid-block .views-view-grid-cols-3 {
-    grid-template-columns: repeat(3, 1fr);
-  }
-  .card-design .view-card-grid .views-grid-box-1 {
-    margin: 1rem 1rem 1rem 0;
-  }
-  .card-design .view-card-grid .views-grid-box-2 {
-    margin: 1rem 0.5rem;
-  }
-  .card-design .view-card-grid .views-grid-box-3 {
-    margin: 1rem 0 1rem 1rem;
-  }
 }


### PR DESCRIPTION
Makes the following suggestions:

* Moves most CSS out of `skin.css`, which is supposed to be used only for colors, into a dedicated `components/cards.css` file.
* Changes the default image style to crop top-center, which looks identical out of the box and works better for photos that include people in them (prevents cut-off heads).
* Instead of modifying the default view provided by node module, I moved the addition of the views filter to standard.install, since the "Card" content type won't exist unless the Standard profile is used.
* Modified the homepage layout further to put the status messages above the cards instead of using the default position below the top area.