### PR TITLE
...more consistent and distinct borders

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -249,7 +249,8 @@
 }
 .layout-editor-block {
   margin: -1px 1px 15px -1px;
-  background: #FFF;
+  background: #ffffff;
+  border: 1px solid #cccccc;
   border-radius: 4px;
   box-shadow: 2px 2px 0 0 #d0d0d0;
 }

--- a/core/modules/layout/css/layout.flexible.admin.css
+++ b/core/modules/layout/css/layout.flexible.admin.css
@@ -1,5 +1,5 @@
 /**
- * Flexible template admin css.
+ * Flexible template admin CSS.
  */
 
 .layout-flexible-region-top .label {
@@ -9,14 +9,14 @@
   line-height: 1.2;
   text-transform: uppercase;
   font-weight: normal;
-  color: #000;
+  color: #000000;
 }
 [dir="rtl"] .layout-flexible-region-top .label {
   padding: 4px 0 4px 12px;
 }
 
 .flexible-row .layout-editor-region {
-  border: 1px solid #EAEAEA;
+  border: 1px solid #cccccc;
 }
 
 .flexible-row .layout-editor-region-title .label {
@@ -29,13 +29,13 @@
 }
 .layout--flexible .layout-editor-block-title {
   padding: 0.4em 1em;
-  margin: 0 -.9375rem .9375rem;
+  margin: 0 -.9375rem .9375rem -.9375rem;
 }
 .layout--flexible .layout-editor-block-title .text {
   font-weight: bold;
 }
 .layout--flexible .layout-editor-block-content p {
-  color: #000;
+  color: #000000;
 }
 
 .layout-flexible-region-top .buttons {
@@ -44,7 +44,7 @@
 
 .layout-flexible-editor .flexible-row {
   padding: 0;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin-bottom: 15px;
   border-radius: 4px;
   cursor: row-resize;
@@ -60,17 +60,17 @@
 }
 
 .flexible-icon {
-  border: 2px solid #999;
+  border: 2px solid #999999;
   border-radius: 3px;
   padding: 1px;
 }
 .flexible-icon-region {
-  background-color: #ccc;
-  color: #fff;
+  color: #ffffff;
+  background: #cccccc;
   background-clip: content-box;
   text-align: center;
 }
 
 .l-content #layout-flexible-content {
-  background-color: #fff;
+  background: #ffffff;
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6325

Based on @stpaultim's PR. Does the following:
- Fixes a missed spot with LTR/RTL for a margin
- changes all `#xxx` color values to `#xxxxxx` instead, as suggested in https://docs.backdropcms.org/css-standards
- adds consistent `1px solid #cccccc;` in various places - see before(Tim's PR)/after(this PR) side-by-side screenshots:
  - template UI:
    ![image](https://github.com/stpaultim/backdrop/assets/2423362/f24cf10d-a435-44a5-997d-14156952f2ae)
  - blocks UI:
    ![image](https://github.com/stpaultim/backdrop/assets/2423362/a224799c-bcd0-483d-8199-84cc6e75aa50)