### PR TITLE
Issue #4782: Eliminating separate Basis default_version_clean variable. Docs and naming updates.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3704,7 +3704,9 @@ function system_update_1099() {
     }
     $config->set('install_version', $version);
     $config->save();
+    return t('Install version set to @version', array('@version' => $version));
   }
+  return t('Install version had already been set, no changes.');
 }
 
 

--- a/core/themes/basis/config/basis.settings.json
+++ b/core/themes/basis/config/basis.settings.json
@@ -1,6 +1,6 @@
 {
     "_config_name": "basis.settings",
-    "default_version_clean": "1.30",
-    "css_update_version": "1.30",
-    "css_update": "default"
+    "_config_static": true,
+    "css_update": "install_version",
+    "css_update_version": "1.30"
 }

--- a/core/themes/basis/template.php
+++ b/core/themes/basis/template.php
@@ -43,13 +43,11 @@ function basis_preprocess_page(&$variables) {
   $update_preference = config_get('basis.settings', 'css_update');
 
   // Process supplemental CSS versions.
-  $update_css_versions = basis_css_versions_updated();
+  $update_css_versions = basis_updated_css_versions();
   foreach ($update_css_versions as $update_css_version) {
-    if ($update_css_version) {
-      if ($update_preference === 'all_updates' || version_compare($update_version, $update_css_version, '>=')) {
-        $update_css_version_class = 'update-' . str_replace('.', '-', $update_css_version);
-        $variables['classes'][] = $update_css_version_class;
-      }
+    if ($update_preference === 'all_updates' || version_compare($update_version, $update_css_version, '>=')) {
+      $update_css_version_class = 'update-' . str_replace('.', '-', $update_css_version);
+      $variables['classes'][] = $update_css_version_class;
     }
   }
 
@@ -69,12 +67,14 @@ function basis_preprocess_page(&$variables) {
 }
 
 /**
- * Every time we add supplemental CSS we add the version number here
- * and update the default config file in Basis.
+ * Returns the versions of Backdrop that contain updated CSS for Basis.
+ *
+ * Every time a new supplemental CSS update is added to core, the core version
+ * should be added to this list. When a new version is added, the
+ * "css_update_version" in basis.settings.json should match the added value.
  */
-
-// TODO: Before merging, we need to reset these values.
-function basis_css_versions_updated() {
+function basis_updated_css_versions() {
+  // TODO: Before merging, we need to reset these values.
   return array('1.31.5', '1.30', '1.28.4', '1.23');
 }
 

--- a/core/themes/basis/theme-settings.php
+++ b/core/themes/basis/theme-settings.php
@@ -76,7 +76,7 @@ if (module_exists('color')) {
   $install_version = config_get('system.core', 'install_version');
 
   $css_update_options = array(
-    'default' => t('Default'),
+    'install_version' => t('Default'),
     'all_updates' => t('All updates'),
     'custom' => t('Specific version'),
   );
@@ -109,7 +109,7 @@ if (module_exists('color')) {
   );
 
   // Custom select css update versions.
-  $options = backdrop_map_assoc(basis_css_versions_updated());
+  $options = backdrop_map_assoc(basis_updated_css_versions());
   $options[''] = t('No updates');
   $default_version_value = theme_get_setting('css_update_version', $theme_name);
   $default_version_key = array_search($default_version_value, $options, TRUE);
@@ -134,20 +134,29 @@ if (module_exists('color')) {
  * Process function to adjust the CSS update version value before saving.
  */
 function basis_process_css_update_value($element, &$form_state, $form) {
-  $css_update = $form_state['values']['css_update'] ?? 'installation';
-  $options = basis_css_versions_updated();
-  $install_version = config_get('basis.settings', 'default_version_clean');
+  $css_update = isset($form_state['values']['css_update']) ? $form_state['values']['css_update'] : 'install_version';
+  $basis_css_versions = basis_updated_css_versions();
+  $install_version = config_get('system.core', 'install_version');
+
+  // Find the CSS update version within Basis that matches the install version.
+  $basis_install_version = '';
+  foreach ($basis_css_versions as $css_version) {
+    if (version_compare($css_version, $install_version, '<')) {
+      break;
+    }
+    $basis_install_version = $css_version;
+  }
 
   // Adjust version value based on preference.
   switch ($css_update) {
-    case 'default':
-      $form_state['values']['css_update_version'] = $install_version;
+    case 'install_version':
+      $form_state['values']['css_update_version'] = $basis_install_version;
       break;
 
     case 'custom':
-      $selected_key = $form_state['values']['css_update_version'] ?? NULL;
-      if (isset($options[$selected_key])) {
-        $form_state['values']['css_update_version'] = $options[$selected_key];
+      $selected_key = isset($form_state['values']['css_update_version']) ? $form_state['values']['css_update_version'] : NULL;
+      if (isset($basis_css_versions[$selected_key])) {
+        $form_state['values']['css_update_version'] = $basis_css_versions[$selected_key];
       }
       break;
   }

--- a/core/themes/basis/theme-settings.php
+++ b/core/themes/basis/theme-settings.php
@@ -69,66 +69,66 @@ if (module_exists('color')) {
   foreach ($fields as $field) {
     $form['footer'][$field] = color_get_color_element($form['theme']['#value'], $field, $form);
   }
-
-  $theme_name = $form['theme']['#value'];
-  $theme_path = backdrop_get_path('theme', 'basis');
-  require_once $theme_path . '/template.php';
-  $install_version = config_get('system.core', 'install_version');
-
-  $css_update_options = array(
-    'install_version' => t('Default'),
-    'all_updates' => t('All updates'),
-    'custom' => t('Specific version'),
-  );
-
-  $form['css_updates'] = array(
-    '#type' => 'details',
-    '#open' => FALSE,
-    '#summary' => t('CSS Updates'),
-    '#details' => t('There are occasionally updates available for Basis that may affect existing sites, changing this setting may cause unexpected changes to your theme. For more information and details, see the <a href="https://docs.backdropcms.org/documentation/layouts-and-templates" target="_blank">online documentation</a>.</br></br>Select which updates you would like to accept. '),
-    '#attributes' => array(
-      'class' => array('description'),
-    ),
-  );
-
-  // Load the saved configuration value.
-  $form['css_updates']['css_update'] = array(
-    '#title' => t('CSS Update Options'),
-    '#type' => 'radios',
-    '#options' => $css_update_options,
-    '#default_value' => theme_get_setting('css_update', $theme_name),
-    '#config' => 'basis.settings',
-    'default' => array(
-      '#description' => t('Accept no updates introduced after installation.'),
-    ),
-    'all_updates' => array(
-      '#description' => t('Warning: Some future changes may effect your site.'),
-    ),
-    'custom' => array(
-    ),
-  );
-
-  // Custom select css update versions.
-  $options = backdrop_map_assoc(basis_updated_css_versions());
-  $options[''] = t('No updates');
-  $default_version_value = theme_get_setting('css_update_version', $theme_name);
-  $default_version_key = array_search($default_version_value, $options, TRUE);
-  $form['css_updates']['css_update_version'] = array(
-    '#type' => 'select',
-    '#title' => t('Version'),
-    '#description' => t('Accept CSS changes up to this specific version of Backdrop.'),
-    '#options' => $options,
-    '#default_value' => $default_version_key,
-    '#empty_option' => t('Default'),
-    '#empty_value' => NULL,
-    '#states' => [
-      'visible' => [
-        ':input[name="css_update"]' => ['value' => 'custom'],
-      ],
-    ],
-    '#process' => ['basis_process_css_update_value'],
-  );
 }
+
+$theme_name = $form['theme']['#value'];
+$theme_path = backdrop_get_path('theme', 'basis');
+require_once $theme_path . '/template.php';
+$install_version = config_get('system.core', 'install_version');
+
+$css_update_options = array(
+  'install_version' => t('Default'),
+  'all_updates' => t('All updates'),
+  'custom' => t('Specific version'),
+);
+
+$form['css_updates'] = array(
+  '#type' => 'details',
+  '#open' => FALSE,
+  '#summary' => t('CSS Updates'),
+  '#details' => t('There are occasionally updates available for Basis that may affect existing sites, changing this setting may cause unexpected changes to your theme. For more information and details, see the <a href="https://docs.backdropcms.org/documentation/layouts-and-templates" target="_blank">online documentation</a>.</br></br>Select which updates you would like to accept. '),
+  '#attributes' => array(
+    'class' => array('description'),
+  ),
+);
+
+// Load the saved configuration value.
+$form['css_updates']['css_update'] = array(
+  '#title' => t('CSS Update Options'),
+  '#type' => 'radios',
+  '#options' => $css_update_options,
+  '#default_value' => theme_get_setting('css_update', $theme_name),
+  '#config' => 'basis.settings',
+  'default' => array(
+    '#description' => t('Accept no updates introduced after installation.'),
+  ),
+  'all_updates' => array(
+    '#description' => t('Warning: Some future changes may effect your site.'),
+  ),
+  'custom' => array(
+  ),
+);
+
+// Custom select css update versions.
+$options = backdrop_map_assoc(basis_updated_css_versions());
+$options[''] = t('No updates');
+$default_version_value = theme_get_setting('css_update_version', $theme_name);
+$default_version_key = array_search($default_version_value, $options, TRUE);
+$form['css_updates']['css_update_version'] = array(
+  '#type' => 'select',
+  '#title' => t('Version'),
+  '#description' => t('Accept CSS changes up to this specific version of Backdrop.'),
+  '#options' => $options,
+  '#default_value' => $default_version_key,
+  '#empty_option' => t('Default'),
+  '#empty_value' => NULL,
+  '#states' => array(
+    'visible' => array(
+      ':input[name="css_update"]' => array('value' => 'custom'),
+    ),
+  ),
+  '#process' => array('basis_process_css_update_value'),
+);
 
 /**
  * Process function to adjust the CSS update version value before saving.


### PR DESCRIPTION
Builds on @stpaultim's pull request with some naming changes and eliminates the need for the "default_version_clean" config value. Now it just uses the system "install_version" instead.